### PR TITLE
fix: support legacy document conversion

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -85,8 +86,10 @@ func (s *Server) handleConvert(w http.ResponseWriter, r *http.Request) {
 	// Build download URL for the source file
 	downloadURL := s.buildDownloadURL(filePath)
 
-	// Generate unique key for conversion
-	conversionKey := fmt.Sprintf("convert_%s_%d", filePath, time.Now().UnixNano())
+	// Generate a stable, opaque key that changes when the source file changes.
+	keyMaterial := fmt.Sprintf("%s\x00%s\x00%d", filePath, fileInfo.ModTime.UTC().Format(time.RFC3339Nano), fileInfo.Size)
+	keyHash := sha256.Sum256([]byte(keyMaterial))
+	conversionKey := "convert-" + fmt.Sprintf("%x", keyHash[:])[:24]
 
 	// Build conversion request
 	convReq := &ConvertRequest{
@@ -195,10 +198,18 @@ func (s *Server) buildTargetPath(sourcePath, targetFormat string) string {
 // callConversionAPI calls the OnlyOffice conversion API
 func (s *Server) callConversionAPI(serverURL string, req *ConvertRequest, secret string) (string, error) {
 	// Build API URL
-	apiURL := strings.TrimSuffix(serverURL, "/") + "/ConvertService.ashx"
+	apiURL := strings.TrimSuffix(serverURL, "/") + "/converter"
 
-	// Marshal request
-	reqBody, err := json.Marshal(req)
+	// JWT_IN_BODY requires a body containing only the signed token.
+	requestBody := interface{}(req)
+	if req.Token != "" {
+		requestBody = struct {
+			Token string `json:"token"`
+		}{Token: req.Token}
+	}
+
+	// Marshal request body
+	reqBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
@@ -211,11 +222,6 @@ func (s *Server) callConversionAPI(serverURL string, req *ConvertRequest, secret
 
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
-
-	// Add JWT token to header if configured
-	if secret != "" && req.Token != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+req.Token)
-	}
 
 	// Send request
 	client := &http.Client{

--- a/web/templates/convert.tmpl
+++ b/web/templates/convert.tmpl
@@ -38,7 +38,7 @@
                                 <button type="submit" class="button is-primary is-fullwidth is-medium mb-3">转换为 {{.TargetFormat}} 并编辑</button>
                             </form>
                             
-                            <a href="/editor?path={{.FilePathEncoded}}&mode=view" class="button is-light is-fullwidth is-medium mb-5">以只读模式查看</a>
+                            <a href="/editor?path={{.FilePath}}&mode=view" class="button is-light is-fullwidth is-medium mb-5">以只读模式查看</a>
                             
                             <p class="has-text-centered">
                                 <a href="/" class="has-text-grey">← 返回设置</a>


### PR DESCRIPTION
## 关联 Issue

Fixes [#3](https://github.com/tf4fun/onlyoffice-fnos/issues/3)

## 问题

部分旧格式文档无法通过“转换并编辑”正常打开。

在 fnOS 与 ONLYOFFICE Document Server 的部署环境中，`.xls` 等旧格式的转换请求曾返回：

```text
conversion error code: -7
```

此外，转换页面的“以只读模式查看”链接会对文件路径进行二次编码，使路径参数变为 `%252F...`，随后导致文件不存在。

## 发现的实现问题

1. Connector 使用旧的 `ConvertService.ashx` 转换端点；当前 ONLYOFFICE Conversion API 文档使用 `/converter`。
2. 转换任务 key 直接包含完整文件路径和时间戳；路径可能包含 `/`、空格或 Unicode 字符，且每次重试都会生成不同的 key。
3. 在 `JWT_IN_BODY=true` 配置下，转换请求同时发送完整 JSON 参数、body token 和 `Authorization` header，未使用单一的 body-token 请求形态。
4. 转换页预先编码路径后，Go `html/template` 又在 URL 上下文中编码 `%`，导致只读链接的路径被二次编码。

## 修改内容

- 将转换端点从 `/ConvertService.ashx` 改为 `/converter`。
- 在 body JWT 模式下仅发送：

  ```json
  { "token": "..." }
  ```

- 使用基于文件路径、修改时间和文件大小的 SHA-256 截断值生成稳定、短且不泄露路径的转换 key。
- 将原始文件路径交给模板进行一次 URL 编码，避免只读链接出现 `%252F`。

## 测试结果

```text
测试环境：fnOS Docker 部署
ONLYOFFICE Document Server 9.4.0（测试时 `onlyoffice/documentserver:latest` 指向该版本）
JWT 已启用且 `JWT_IN_BODY=true`。
```

### 旧格式转换与编辑

- [x] `.doc`：含中文、多页文字、表格与图片；确认转换为 `.docx` 后可编辑、保存并重新打开。
- [x] `.xls`：含多个工作表、公式、日期、合并单元格与中文；确认转换为 `.xlsx` 后可编辑、保存并重新打开。
- [x] `.ppt`：含文本框、图片和多页幻灯片；确认转换为 `.pptx` 后可编辑、保存并重新打开。
- [x] `.rtf`：含中文、粗体与颜色；确认转换为 `.docx` 后可编辑。

### CSV 兼容性

- [x] UTF-8、逗号分隔 CSV：确认中文无乱码，列能正确拆分。
- [x] UTF-8、分号分隔 CSV：确认列分隔行为符合预期。
- [x] GBK、逗号分隔 CSV：只读预览时手动选择 GBK 编码和逗号分隔后可正常显示。
- [ ] GBK、逗号分隔 CSV 的“转换并编辑”：生成的 XLSX 中文丢失。该路径未向 Conversion API 传递 CSV 的 `codePage` 与 `delimiter` 参数，作为后续独立问题处理，不属于本 PR 范围。
- [x] 含逗号和双引号字段的 CSV：确认转换后数据未错列或截断。

### 只读预览与路径编码

- [x] `.doc`、`.xls`、`.ods`、`.ppt` 分别点击“以只读模式查看”，确认可打开且为只读状态。
- [x] 确认浏览器地址中的 `path` 只编码一次，例如 `path=%2Fvol3%2F...`，而不是 `path=%252Fvol3%252F...`。
- [x] 使用中文目录、中文文件名和空格目录测试 `.xls`，确认转换与只读预览均正常。

### 大文件、重复转换与回归

- [x] 使用 10 MB 以上、数万行的 `.xls`，确认转换未超时。
- [x] 同一源文件连续转换两次，确认不会生成损坏或异常命名的目标文件。
- [ ] 已存在同名目标格式文件时，当前实现会覆盖该目标文件；该行为为现有设计，未在本 PR 中修改。
- [x] `.docx`、`.xlsx`、`.pptx` 各完成一次打开、编辑、保存和重新打开，确认没有回归。

## 范围

此 PR 仅修改旧格式转换与只读链接编码逻辑：

- `internal/server/convert.go`
- `web/templates/convert.tmpl`

## 开发说明

本修复在人工审查和实际部署验证的基础上，使用 OpenCode、oh-my-opencode-slim 与 GPT-5.6 Terra 辅助完成。